### PR TITLE
update remove script

### DIFF
--- a/plugins/preclear.disk.plg
+++ b/plugins/preclear.disk.plg
@@ -181,6 +181,7 @@ The 'remove' script.
 <INLINE>
 
 # Remove plugin related files
+removepkg /boot/config/plugins/&name;/&name;-&version;.txz
 rm -rf /boot/config/plugins/&name; \
        /usr/local/emhttp/plugins/&name; \
        /var/state/&name;


### PR DESCRIPTION
The plugin package needs to be removed.  If not, a reinstall of the same plugin version will fail. 
"Skipping package preclear.disk-2015.11.18 (already installed)"

Thanks for the install and remove scripts, especially the md5 check of the github package. I will use this method.