### PR TITLE
update remove script

### DIFF
--- a/plugins/unassigned.devices.plg
+++ b/plugins/unassigned.devices.plg
@@ -350,6 +350,7 @@ rmdir /mnt/disks
 find "/boot/config/plugins/&name;/packages/" -type f -iname "*.txz" -delete
 
 # Remove possible leftovers
+removepkg &packages;/&name;-&version;.txz
 rm -rf /usr/local/emhttp/plugins/&name; \
        /var/state/&name; \
        &packages;


### PR DESCRIPTION

The plugin package needs to be removed. If not, a reinstall of the same plugin version will fail.
"Skipping package unassigned.devices-2015.11.18 (already installed)"

Thanks for the install and remove scripts, especially the md5 check of the github package. I will use this method.