### PR TITLE
Preclear Disk: upgradepkg ncurses

### DIFF
--- a/plugins/preclear.disk.beta.plg
+++ b/plugins/preclear.disk.beta.plg
@@ -143,7 +143,7 @@ libevent-2.0.21-x86_64-1.txz
 <!--
 ncurses-5.9-x86_64-2.txz
 -->
-<FILE Name="/boot/config/plugins/&name;/ncurses-5.9-x86_64-2.txz" Run="installpkg">
+<FILE Name="/boot/config/plugins/&name;/ncurses-5.9-x86_64-2.txz" Run="upgradepkg --install-new">
 <URL>http://slackware.osuosl.org/slackware64-14.1/slackware64/l/ncurses-5.9-x86_64-2.txz</URL>
 <MD5>9134fa31097ee352a1f1662e3f6bcb3f</MD5>
 </FILE>

--- a/plugins/preclear.disk.plg
+++ b/plugins/preclear.disk.plg
@@ -132,7 +132,7 @@ libevent-2.0.21-x86_64-1.txz
 <!--
 ncurses-5.9-x86_64-2.txz
 -->
-<FILE Name="/boot/config/plugins/&name;/ncurses-5.9-x86_64-2.txz" Run="installpkg">
+<FILE Name="/boot/config/plugins/&name;/ncurses-5.9-x86_64-2.txz" Run="upgradepkg --install-new">
 <URL>http://slackware.osuosl.org/slackware64-14.1/slackware64/l/ncurses-5.9-x86_64-2.txz</URL>
 <MD5>9134fa31097ee352a1f1662e3f6bcb3f</MD5>
 </FILE>


### PR DESCRIPTION
unRAID 6.2 ships with `ncurses-5.9-x86_64-4` already installed (unRAID 6.1.x doesn't ship with ncurses at all) so it's safer to use `upgradepkg --install-new` to not downgrade the ncurses package `ncurses-5.9-x86_64-2` on unRAID 6.2 while still installing it on unRAID 6.1 safely.